### PR TITLE
Correctly split genres using get_text(), handling with missing plot source

### DIFF
--- a/src/csfd_parsers.py
+++ b/src/csfd_parsers.py
@@ -509,10 +509,15 @@ class MovieParser:
                 "author": text(main_plot_author_tag),
                 "text": text(other_plot_tag, rec_tags=["a", "em"], is_not=["em.span-more-small"])
             })
+        main_plot_source_name = ""
+        main_plot_source_url = ""
+        if main_plot_source_tag != None:
+            main_plot_source_name = text(main_plot_source_tag)
+            main_plot_source_url = main_plot_source_tag.get("href")
         return {
             "main_plot": {
-                "source_name": text(main_plot_source_tag),
-                "source_url": main_plot_source_tag.get("href"),
+                "source_name": main_plot_source_name,
+                "source_url": main_plot_source_url,
                 "text": text(main_plot_tag, rec_tags=["a", "em"], is_not=["em.span-more-small"])
             },
             "other_plots": other_plots

--- a/src/csfd_parsers.py
+++ b/src/csfd_parsers.py
@@ -351,7 +351,7 @@ class MovieParser:
     @staticmethod
     def parse_movie_genres(s: BeautifulSoup) -> List[str]:
         genres = sel(s, ".genres")
-        return [] if genres is None else text(genres).split(" / ")
+        return [] if genres is None else genres.get_text().split(" / ")
 
     @staticmethod
     def parse_movie_origins(s: BeautifulSoup) -> List[str]:


### PR DESCRIPTION
Fix:

./csfd_scraper/cli.py movie -m 223800 --rating --genres

old:

"genres": [
        "/"
    ]

new:

 "genres": [
        "Drama",
        "Thriller"
    ],